### PR TITLE
Bump to form-urlencoded@6

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,9 +16,7 @@
 'use strict';
 
 var getEndpoint = require('get-webmention-url'),
-    // Annoyingly this package just *had* to be fancy and switch to ES6 `export`.
-    // That's why I'm forced to put this ugly-ass `.default` stupidity here.
-    formurlencoded = require('form-urlencoded').default,
+    formurlencoded = require('form-urlencoded'),
     url = require('url'),
     http = require('http'),
     https = require('https'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.0",
       "license": "LGPL-3.0+",
       "dependencies": {
-        "form-urlencoded": "^4.0.0",
+        "form-urlencoded": "^6.1.0",
         "get-webmention-url": "^2.0.0"
       },
       "devDependencies": {
@@ -1260,9 +1260,9 @@
       }
     },
     "node_modules/form-urlencoded": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/form-urlencoded/-/form-urlencoded-4.5.1.tgz",
-      "integrity": "sha512-Rkd/RdMaprsMJEGzEbxolwacp78WupH7u369KEyIY3pEZ1fhL6HtyQ1FX+4HSfA1VVhET18UwCUcr5DVaDIaqg=="
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/form-urlencoded/-/form-urlencoded-6.1.0.tgz",
+      "integrity": "sha512-lc1Qd9nnEewXKoiPjIA1n38M5STbyY6krgoegsg7SsAt2b98HZKe25KaJvKFBwQaOcmh8FP7JbXVC7gocZw+XQ=="
     },
     "node_modules/fromentries": {
       "version": "1.3.2",
@@ -4081,9 +4081,9 @@
       }
     },
     "form-urlencoded": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/form-urlencoded/-/form-urlencoded-4.5.1.tgz",
-      "integrity": "sha512-Rkd/RdMaprsMJEGzEbxolwacp78WupH7u369KEyIY3pEZ1fhL6HtyQ1FX+4HSfA1VVhET18UwCUcr5DVaDIaqg=="
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/form-urlencoded/-/form-urlencoded-6.1.0.tgz",
+      "integrity": "sha512-lc1Qd9nnEewXKoiPjIA1n38M5STbyY6krgoegsg7SsAt2b98HZKe25KaJvKFBwQaOcmh8FP7JbXVC7gocZw+XQ=="
     },
     "fromentries": {
       "version": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Send a Webmention",
   "main": "index.js",
   "dependencies": {
-    "form-urlencoded": "^4.0.0",
+    "form-urlencoded": "^6.1.0",
     "get-webmention-url": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Opening this mostly to trigger CI to find out if the `exports` sheanigans in upstream `package.json` work on all supported Node versions